### PR TITLE
feat: add order detail page

### DIFF
--- a/app/src/api/operations.ts
+++ b/app/src/api/operations.ts
@@ -1,11 +1,19 @@
 import { post } from "@/utils/http";
 
 const Api = {
-    BatchDelete: "/batchDelete"
+    BatchDelete: "/batchDelete",
+    QueryOrderDetail:"/orders/detail"
 } as const;
 
 function batchDeleteApi(order: string[]) {
     return post(Api.BatchDelete,{order})
 }
 
-export {batchDeleteApi}
+function queryOrderDetailApi(orderNo: string) {
+    return post(Api.QueryOrderDetail,orderNo)
+}
+
+export {
+    batchDeleteApi,
+    queryOrderDetailApi
+}

--- a/app/src/layouts/TabsLayout.vue
+++ b/app/src/layouts/TabsLayout.vue
@@ -22,7 +22,12 @@
             </template>
         </el-tab-pane>
     </el-tabs>
-    <RouterView/>
+    <RouterView v-slot="{Component}">
+        <KeepAlive>
+            <component :is="Component" :key="$route.name" v-if="$route.meta.keepAlive"></component>
+        </KeepAlive>
+        <component :is="Component" :key="$route.name" v-if="!$route.meta.keepAlive"></component>
+    </RouterView>
 </template>
 
 <script setup lang="ts">

--- a/app/src/mock/index.ts
+++ b/app/src/mock/index.ts
@@ -2064,3 +2064,14 @@ Mock.mock('https://www.demo.com/batchDelete', "post", (options: any) => {
     data: "Delete Successfully"
   }
 })
+
+//Operations-orders-detail API
+Mock.mock('https://www.demo.com/orders/detail', "post", (options: any) => {
+  
+ console.log("The backend got it:", options.body)
+  return {
+    code: 200,
+    message: "successful",
+    data: options.body+" Detail"
+  }
+})

--- a/app/src/router/basicRouteMap.ts
+++ b/app/src/router/basicRouteMap.ts
@@ -1,3 +1,4 @@
+import { KeepAlive } from "vue";
 import type { RouteRecordRaw } from "vue-router";
 
 const routes: RouteRecordRaw[] = [
@@ -35,12 +36,18 @@ const routes: RouteRecordRaw[] = [
             {
                 path: "/operations/orders",
                 name: "orders",
-                component: () => import("@/views/operations/Orders.vue")
+                component: () => import("@/views/operations/Orders.vue"),
+                meta: {
+                    keepAlive:true
+                }
             },
             {
                 path: "/operations/detail",
                 name: "detail",
-                component: () => import("@/views/operations/Detail.vue")
+                component: () => import("@/views/operations/Detail.vue"),
+                meta: {
+                    keepAlive:true
+                }
             },
             {
                 path: "/operations/total",

--- a/app/src/views/operations/Detail.vue
+++ b/app/src/views/operations/Detail.vue
@@ -1,3 +1,33 @@
 <template>
-    Detail view
+    <el-card>
+        <el-descriptions :title="`Order No. ${$route.query.orderNo}`">
+            <el-descriptions-item label="From Gary">
+                We’re no longer using mock data to show the order details here. You can see from the tab above and the Order No. on this page that the parameter has been successfully passed from the Order page. If you check the console, you’ll see the backend also received the correct order number. This means we’ve successfully completed the order detail view feature.
+            </el-descriptions-item>
+        </el-descriptions>
+    </el-card>
 </template>
+
+<script setup lang="ts">
+import { queryOrderDetailApi } from '@/api/operations';
+import { onMounted,watch } from 'vue';
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+
+async function loadDetail() {
+  const orderNo = route.query.orderNo as string
+  const res = await queryOrderDetailApi(orderNo)
+  if (res.code === 200) {
+    console.log("Backend responded:",res.data)
+  }
+}
+
+onMounted(loadDetail)
+
+watch(() => route.query.orderNo, (val, oldVal) => {
+  if (val && val !== oldVal) loadDetail()
+})
+
+</script>

--- a/app/src/views/operations/Orders.vue
+++ b/app/src/views/operations/Orders.vue
@@ -64,7 +64,7 @@
             </el-table-column>
             <el-table-column label="Operate" width="160">
                 <template #default="scope">
-                    <el-button type="primary" size="small">Details</el-button>
+                    <el-button type="primary" size="small" @click="handleOrderDetail(scope.row.orderNo)">Details</el-button>
                     <el-button type="danger" size="small">Delete</el-button>
                 </template>
             </el-table-column>
@@ -84,10 +84,12 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue"
+import { ref, watch } from "vue"
 import { useQueryTable } from "@/hooks/useQueryTable"
 import { batchDeleteApi } from "@/api/operations"
 import { ElMessage } from "element-plus"
+import { useRouter,useRoute } from "vue-router"
+import { useTabsStore } from "@/store/tabs"
 
 interface OrderQueryType{
     orderNo: string,
@@ -168,5 +170,24 @@ const handleBatchDelete = async() => {
         console.log(error)
     }
 }
-    
+
+const router = useRouter()
+const tabStore=useTabsStore()
+const {addTab,setCurrentTab}=tabStore
+const handleOrderDetail = (orderNo: string) => {
+    console.log("From Orders view: order No.",orderNo)
+    addTab(orderNo + " Detail", "/operations/detail?orderNo="+orderNo, "Share")
+    setCurrentTab(orderNo + " Detail", "/operations/detail?orderNo="+orderNo)
+    router.push("/operations/detail?orderNo="+orderNo)
+}
+
+const route = useRoute()
+
+watch(() => route.name, (to, from) => {
+    // console.log(to, from)
+    if (to == "orders" && from != "detail") {
+        loadData()
+    }
+})
+
 </script>


### PR DESCRIPTION
- Implemented order detail page and backend integration
- Enabled KeepAlive to cache detail pages
- Supported opening multiple order detail pages at the same time without losing state
